### PR TITLE
Accomodate new chrome mobile api

### DIFF
--- a/src/component/handlers/composition/DraftEditorCompositionHandler.js
+++ b/src/component/handlers/composition/DraftEditorCompositionHandler.js
@@ -42,6 +42,11 @@ const RESOLVE_DELAY = 20;
 let resolved = false;
 let stillComposing = false;
 let textInputData = '';
+/**
+ * New versions of mobile Chrome don't fire `textinput` (converted to `beforeinput`) event,
+ * so we'll save data from `compositionend` event.
+ */
+let compositionTextData = '';
 
 var DraftEditorCompositionHandler = {
   onBeforeInput: function(editor: DraftEditor, e: SyntheticInputEvent): void {
@@ -70,9 +75,10 @@ var DraftEditorCompositionHandler = {
    * twice could break the DOM, we only use the first event. Example: Arabic
    * Google Input Tools on Windows 8.1 fires `compositionend` three times.
    */
-  onCompositionEnd: function(editor: DraftEditor): void {
+  onCompositionEnd: function(editor: DraftEditor, e: SyntheticInputEvent): void {
     resolved = false;
     stillComposing = false;
+    compositionTextData = e.data;
     setTimeout(() => {
       if (!resolved) {
         DraftEditorCompositionHandler.resolveComposition(editor);
@@ -133,8 +139,11 @@ var DraftEditorCompositionHandler = {
     }
 
     resolved = true;
-    const composedChars = textInputData;
+    // If we're on a new mobile Chrome, `textInputData` may be empty here,
+    // so `compositionTextData` from `compositionend` will be used.
+    const composedChars = textInputData || compositionTextData;
     textInputData = '';
+    compositionTextData = '';
 
     const editorState = EditorState.set(editor._latestEditorState, {
       inCompositionMode: false,


### PR DESCRIPTION
Problem: https://app.asana.com/0/211672692333429/342201639039718

This duplicates the changes in https://github.com/pofigizm/draft-js/commit/87ccadc56c94ffa6df813160ec81496b6b404810,
which are draft-js's best current plan of attack to address this issue. That fork was referenced in this comment https://github.com/facebook/draft-js/issues/1077#issuecomment-307379581.
Until we get more input on my other comment in that thread, https://github.com/facebook/draft-js/issues/1077#issuecomment-320383251, implementing this fix on our own might be our best option to support our users.